### PR TITLE
Update Reconcile to skip the management cluster

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -54,6 +54,12 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	// Skip reconciliation for the management cluster
+	if IsManagementCluster(cluster) {
+		log.Info(fmt.Sprintf("Skipping reconciliation for management cluster %s", cluster.Name))
+		return ctrl.Result{}, nil
+	}
+
 	// if control plane is not ready, return and requeue
 	if !cluster.Status.ControlPlaneReady {
 		log.Info(fmt.Sprintf("cluster %s is not ready", cluster.Name))

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -182,4 +183,13 @@ func CreateOrUpdateClusterRoleBinding(ctx context.Context, clientset *kubernetes
 // this token is used to authenticate with the target cluster along with the CA
 func GetServiceAccountBearerToken(ctx context.Context, clientset *kubernetes.Clientset, svcscrt corev1.Secret) ([]byte, error) {
 	return svcscrt.Data["token"], nil
+}
+
+// IsManagementCluster checks if the cluster is the management cluster
+func IsManagementCluster(cluster capi.Cluster) bool {
+	// Check if the cluster has a label that marks it as the management cluster
+	if val, ok := cluster.Labels["management-cluster"]; ok && val == "true" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Updates the `Reconcile` function to skip the management cluster if has the label `management-cluster`.
This PR fixes the issue of ArgoCD adding the management cluster twice (`in-cluster` and `management-cluster-name`)